### PR TITLE
clear event now calls the callback if stack was not empty

### DIFF
--- a/js/undomanager.js
+++ b/js/undomanager.js
@@ -86,8 +86,14 @@ var UndoManager = function () {
 		Clears the memory, losing all stored states.
 		*/
 		clear: function () {
+			var prev_size = commandStack.length;
+
 			commandStack = [];
 			index = -1;
+
+			if ( callback && ( prev_size > 0 ) ) {
+				callback();
+			}
 		},
 
 		hasUndo: function () {


### PR DESCRIPTION
Following the README, writing this:

```
var onUndoChanged = function(undoManager) {
    $('.btnUndo').attr('disabled', !undoManager.hasUndo());
    $('.btnRedo').attr('disabled', !undoManager.hasRedo());
};
    myUndoManager.setCallback(onUndoChanged)
```

was not good enough - because after clear event buttons stayed on. In the demo you called updateUI after each action, but since it is called automatically from undo & redo, it seems only fair to have it called automatically from clear as well.
