### PR TITLE
Remove hardcoded <canvas> element id in CircleDrawer constructor

### DIFF
--- a/demo/js/circledrawer.js
+++ b/demo/js/circledrawer.js
@@ -3,8 +3,8 @@
 var CircleDrawer = function (canvasId, undoManager) {
     "use strict";
 
-    var CANVAS_WIDTH = document.getElementById("view").width,
-        CANVAS_HEIGHT = document.getElementById("view").height,
+    var CANVAS_WIDTH = document.getElementById(canvasId).width,
+        CANVAS_HEIGHT = document.getElementById(canvasId).height,
         MIN_CIRCLE_RADIUS = 10,
         MAX_CIRCLE_RADIUS = 40,
         drawingContext,


### PR DESCRIPTION
A canvas id is passed to the `CircleDrawer` constructor in demo.js, but it's not respected in `CircleDrawer`'s code. 
So I replaced the hardcoded `view` string in `CircleDrawer`'s constructor with the `canvasId` argument.

Now the user can freely change the canvas id in his code and the CircleDrawer should work correctly.
