### PR TITLE
UMD shim for Webpack, Browserify and RequireJS compatability w/o shims

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ Get notified on changes.
 
 
 
+## Use with CommonJS (Webpack, Browserify, Node, etc)
+
+`npm install undo-manager`
+
+`var UndoManager = require('undo-manager')`
+
+If you only need a single instance of UndoManager throughout your application, it may be wise
+to create a module that exports a singleton:
+
+In `undoManager.js`:
+
+    var UndoManager = require('undo-manager'); //require the lib from node_modules
+    var singleton;
+
+    if(!singleton)
+        singleton = new UndoManager();
+
+    module.exports = singleton;
+
+Then throughout your app:
+
+    var undoManager = require('undoManager');
+
+    undoManager.add(...);
+    undoManager.undo();
 
 
 

--- a/lib/undomanager.js
+++ b/lib/undomanager.js
@@ -3,132 +3,148 @@ Simple Javascript undo and redo.
 https://github.com/ArthurClemens/Javascript-Undo-Manager
 */
 
-Array.prototype.removeFromTo = function(from, to) {
-    this.splice(from,
-        !to ||
-        1 + to - from + (!(to < 0 ^ from >= 0) && (to < 0 || -1) * this.length));
-    return this.length;
-};
+;(function() {
 
-var UndoManager = function () {
-    "use strict";
+	'use strict';
 
-    var commands = [],
-        index = -1,
-        limit = 0,
-        isExecuting = false,
-        callback,
-        
-        // functions
-        execute;
+    function removeFromTo(array, from, to) {
+        array.splice(from,
+            !to ||
+            1 + to - from + (!(to < 0 ^ from >= 0) && (to < 0 || -1) * array.length));
+        return array.length;
+    }
 
-    execute = function(command, action) {
-        if (!command || typeof command[action] !== "function") {
+    var UndoManager = function() {
+
+        var commands = [],
+            index = -1,
+            limit = 0,
+            isExecuting = false,
+            callback,
+            
+            // functions
+            execute;
+
+        execute = function(command, action) {
+            if (!command || typeof command[action] !== "function") {
+                return this;
+            }
+            isExecuting = true;
+
+            command[action]();
+
+            isExecuting = false;
             return this;
-        }
-        isExecuting = true;
+        };
 
-        command[action]();
+        return {
 
-        isExecuting = false;
-        return this;
+            /*
+            Add a command to the queue.
+            */
+            add: function (command) {
+                if (isExecuting) {
+                    return this;
+                }
+                // if we are here after having called undo,
+                // invalidate items higher on the stack
+                commands.splice(index + 1, commands.length - index);
+
+                commands.push(command);
+                
+                // if limit is set, remove items from the start
+                if (limit && commands.length > limit) {
+                    removeFromTo(commands, 0, -(limit+1));
+                }
+                
+                // set the current index to the end
+                index = commands.length - 1;
+                if (callback) {
+                    callback();
+                }
+                return this;
+            },
+
+            /*
+            Pass a function to be called on undo and redo actions.
+            */
+            setCallback: function (callbackFunc) {
+                callback = callbackFunc;
+            },
+
+            /*
+            Perform undo: call the undo function at the current index and decrease the index by 1.
+            */
+            undo: function () {
+                var command = commands[index];
+                if (!command) {
+                    return this;
+                }
+                execute(command, "undo");
+                index -= 1;
+                if (callback) {
+                    callback();
+                }
+                return this;
+            },
+
+            /*
+            Perform redo: call the redo function at the next index and increase the index by 1.
+            */
+            redo: function () {
+                var command = commands[index + 1];
+                if (!command) {
+                    return this;
+                }
+                execute(command, "redo");
+                index += 1;
+                if (callback) {
+                    callback();
+                }
+                return this;
+            },
+
+            /*
+            Clears the memory, losing all stored states. Reset the index.
+            */
+            clear: function () {
+                var prev_size = commands.length;
+
+                commands = [];
+                index = -1;
+
+                if (callback && (prev_size > 0)) {
+                    callback();
+                }
+            },
+
+            hasUndo: function () {
+                return index !== -1;
+            },
+
+            hasRedo: function () {
+                return index < (commands.length - 1);
+            },
+
+            getCommands: function () {
+                return commands;
+            },
+            
+            setLimit: function (l) {
+                limit = l;
+            }
+        };
     };
 
-    return {
+	if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(function() {
+			return UndoManager;
+		});
+	} else if (typeof module !== 'undefined' && module.exports) {
+		module.exports = UndoManager;
+	} else {
+		window.UndoManager = UndoManager;
+	}
 
-        /*
-        Add a command to the queue.
-        */
-        add: function (command) {
-            if (isExecuting) {
-                return this;
-            }
-            // if we are here after having called undo,
-            // invalidate items higher on the stack
-            commands.splice(index + 1, commands.length - index);
-
-            commands.push(command);
-            
-            // if limit is set, remove items from the start
-            if (limit && commands.length > limit) {
-                commands.removeFromTo(0, -(limit+1));
-            }
-            
-            // set the current index to the end
-            index = commands.length - 1;
-            if (callback) {
-                callback();
-            }
-            return this;
-        },
-
-        /*
-        Pass a function to be called on undo and redo actions.
-        */
-        setCallback: function (callbackFunc) {
-            callback = callbackFunc;
-        },
-
-        /*
-        Perform undo: call the undo function at the current index and decrease the index by 1.
-        */
-        undo: function () {
-            var command = commands[index];
-            if (!command) {
-                return this;
-            }
-            execute(command, "undo");
-            index -= 1;
-            if (callback) {
-                callback();
-            }
-            return this;
-        },
-
-        /*
-        Perform redo: call the redo function at the next index and increase the index by 1.
-        */
-        redo: function () {
-            var command = commands[index + 1];
-            if (!command) {
-                return this;
-            }
-            execute(command, "redo");
-            index += 1;
-            if (callback) {
-                callback();
-            }
-            return this;
-        },
-
-        /*
-        Clears the memory, losing all stored states. Reset the index.
-        */
-        clear: function () {
-            var prev_size = commands.length;
-
-            commands = [];
-            index = -1;
-
-            if (callback && (prev_size > 0)) {
-                callback();
-            }
-        },
-
-        hasUndo: function () {
-            return index !== -1;
-        },
-
-        hasRedo: function () {
-            return index < (commands.length - 1);
-        },
-
-        getCommands: function () {
-            return commands;
-        },
-        
-        setLimit: function (l) {
-            limit = l;
-        }
-    };
-};
+}());

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -7,7 +7,7 @@
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.js"></script>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine-html.js"></script>
 
-  <script type="text/javascript" src="../js/undomanager.js"></script>
+  <script type="text/javascript" src="../lib/undomanager.js"></script>
   <script type="text/javascript" src="spec/UndoManagerSpec.js"></script>
 
   <script type="text/javascript">


### PR DESCRIPTION
It looks like a lot of changes, but it's really not. It's just wrapped in a function with the UMD shim added at the bottom, the test runner fixed and I took the liberty of not modifying the global Array.prototype since it was only used once (it's generally a bad practice to modify primitive objects unless absolutely necessary).

Tested and all tests pass. 