### PR TITLE
ADD: group undo/redo support; "Group" button to demo file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root=true
+[*.js]
+charset = utf-8
+indent_style=space
+indent_size=4

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Get notified on changes.
 Returns the index of the actions list.
 
 
+    var groupID = undoManager.group(stepsBefore);
+
+Returns the group index of the new group, which will be created from steps before current index.
+
+
+    var commandsArray = undoManager.getGroup(groupID);
+
+Returns the commands array from group index.
+
+
 
 ## Use with CommonJS (Webpack, Browserify, Node, etc)
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,11 +13,13 @@
                     <button type="button" class="btn btn-primary" id="btnRedo" disabled="disabled">Redo</button>
                     <input type="number" min="0" max="10" class="form-control" id="ctrlLimit" placeholder="Limit: 0" />
                     <button type="button" class="btn btn-default pull-right" id="btnClear">Clear memory</button>
+                    <button type="button" class="btn btn-default pull-right" id="btnGroup">Group</button>
                 </div>
                 <div>
                     <canvas id="view" width="600" height="400"></canvas>
                 </div>
                 <p class="comment mute">Click on the area to create circles</p>
+                <p class="comment mute">Group button is to toggle a new group (batch undo/redo).</p>
             </div>
         </div>
         

--- a/demo/js/demo.js
+++ b/demo/js/demo.js
@@ -4,8 +4,10 @@ window.onload = function () {
     var undoManager,
         ctrlLimit,
         circleDrawer,
+        groups,
         btnUndo,
         btnRedo,
+        btnGroup,
         btnClear;
 
     undoManager = new UndoManager();    
@@ -15,6 +17,7 @@ window.onload = function () {
     btnUndo = document.getElementById("btnUndo");
     btnRedo = document.getElementById("btnRedo");
     btnClear = document.getElementById("btnClear");
+    btnGroup = document.getElementById("btnGroup");
 
     function updateUI() {
         btnUndo.disabled = !undoManager.hasUndo();
@@ -33,6 +36,15 @@ window.onload = function () {
     btnClear.onclick = function () {
         undoManager.clear();
         updateUI();
+    };
+    btnGroup.onclick = function() {
+        var c = btnGroup.classList;
+        if(c.contains('active')){
+            undoManager.group(undoManager.getIndex()-groups)
+        }else{
+            groups = undoManager.getIndex()
+        }
+        c.toggle('active');
     };
     var handleLimit = function(l) {
         var limit = parseInt(l, 10);

--- a/lib/undomanager.js
+++ b/lib/undomanager.js
@@ -18,10 +18,11 @@ https://github.com/ArthurClemens/Javascript-Undo-Manager
 
         var commands = [],
             index = -1,
+            groupIndex = 0,
             limit = 0,
             isExecuting = false,
             callback,
-            
+
             // functions
             execute;
 
@@ -51,12 +52,12 @@ https://github.com/ArthurClemens/Javascript-Undo-Manager
                 commands.splice(index + 1, commands.length - index);
 
                 commands.push(command);
-                
+
                 // if limit is set, remove items from the start
                 if (limit && commands.length > limit) {
                     removeFromTo(commands, 0, -(limit+1));
                 }
-                
+
                 // set the current index to the end
                 index = commands.length - 1;
                 if (callback) {
@@ -80,8 +81,13 @@ https://github.com/ArthurClemens/Javascript-Undo-Manager
                 if (!command) {
                     return this;
                 }
+              var g = command.group;
+              while(command.group === g){
                 execute(command, "undo");
                 index -= 1;
+                command = commands[index];
+                if(!command || !command.group) break;
+              }
                 if (callback) {
                     callback();
                 }
@@ -96,13 +102,28 @@ https://github.com/ArthurClemens/Javascript-Undo-Manager
                 if (!command) {
                     return this;
                 }
+              var g = command.group;
+              while(command.group === g){
                 execute(command, "redo");
                 index += 1;
+                command = commands[index+1];
+                if(!command || !command.group) break;
+              }
                 if (callback) {
                     callback();
                 }
                 return this;
             },
+
+          group: function(step, idx){
+            if(!step) return groupIndex;
+            idx = idx || index;
+            if(step<1) step = 1;
+            groupIndex += 1;
+            while(step-- && idx-step>=0)
+              commands[idx-step].group = groupIndex;
+            return groupIndex;
+          },
 
             /*
             Clears the memory, losing all stored states. Reset the index.
@@ -111,7 +132,8 @@ https://github.com/ArthurClemens/Javascript-Undo-Manager
                 var prev_size = commands.length;
 
                 commands = [];
-                index = -1;
+              index = -1;
+              groupIndex = 0;
 
                 if (callback && (prev_size > 0)) {
                     callback();
@@ -133,7 +155,15 @@ https://github.com/ArthurClemens/Javascript-Undo-Manager
             getIndex: function() {
                 return index;
             },
-            
+
+          getGroup: function(g) {
+            var G = [];
+            for(var i = 0, len = commands.length; i < len; i++) {
+              if( commands[i].group === g ) G.push( {index:i, command:commands[i]} );
+            }
+            return G;
+          },
+
             setLimit: function (l) {
                 limit = l;
             }

--- a/test/spec/UndoManagerSpec.js
+++ b/test/spec/UndoManagerSpec.js
@@ -135,6 +135,33 @@ describe("UndoManager Suite", function() {
         expect(undoManager.getIndex()).toBe(-1);
     });
     
+    it("Calling undo/redo with group", function() {
+        addItem("A")
+        addItemToUndo("A");
+        addItem("B");
+        addItemToUndo("B");
+        var groupID = undoManager.group(2);
+        addItem("C");
+        addItemToUndo("C");
+
+        undoManager.undo();
+        undoManager.undo();
+        expect(items.length).toBe(0);
+        expect(undoManager.hasUndo()).toBe(false);
+        expect(undoManager.getCommands().length).toBe(3);
+        expect(undoManager.getIndex()).toBe(-1);
+        expect(undoManager.getGroup(groupID).length).toBe(2);
+
+        undoManager.redo();
+        undoManager.redo();
+        expect(items.length).toBe(3);
+        expect(undoManager.hasRedo()).toBe(false);
+        expect(undoManager.getCommands().length).toBe(3);
+        expect(undoManager.getIndex()).toBe(2);
+        expect(undoManager.getGroup(groupID).length).toBe(2);
+
+    });
+    
     it("Calling clear", function() {
         addItemToUndo("A");
         addItemToUndo("B");


### PR DESCRIPTION
There's some need for `grouped` undo/redo actions, like serial user input, a module that will generate several **redo**, and then want to **undo** for the whole module action, etc.

Please see updated demo files, click on Group button, trigger some actions, toggle it, add some more actions, undo...

BTW, is there a need for `.editorconfig` file? I found it's convinient to maintain same format, and I really spend some time to keep same format as your lib, but still there's some spaces removed by emacs.
